### PR TITLE
Make changes to the edit-save page

### DIFF
--- a/src/frontend/project-src/components/editchart/DownloadOptions.jsx
+++ b/src/frontend/project-src/components/editchart/DownloadOptions.jsx
@@ -1,5 +1,7 @@
 import { useEffect, useCallback, useState } from 'react';
 import { FileDown, Image, FileImage, X, Loader2 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { CheckCircle } from 'lucide-react';
 
 
 async function downloadChart(format, chartImageUrl) {
@@ -34,16 +36,28 @@ async function downloadChart(format, chartImageUrl) {
 
 function DownloadOptions({ onClose, chartImageUrl }) {
   const [downloading, setDownloading] = useState(null); // Track which format is downloading
+  const [downloadSuccessful, setDownloadSuccessful] = useState(false);
+  const navigate = useNavigate();
 
   const handleDownload = async (format) => {
     setDownloading(format);
     try {
       await downloadChart(format, chartImageUrl);
+      setDownloadSuccessful(true);
     } catch (error) {
       console.error('Download error:', error);
     } finally {
       setDownloading(null);
     }
+  };
+
+  const handleContinueEditing = () => {
+    onClose(); 
+  };
+
+  const handleMakeAnotherChart = () => {
+    navigate('/'); 
+    onClose();
   };
 
   const handleEscapeKey = useCallback((event) => {
@@ -62,7 +76,7 @@ function DownloadOptions({ onClose, chartImageUrl }) {
   return (
     <div
       className="fixed inset-0 bg-opacity-50 flex items-center justify-center z-50 p-4"
-      onClick={onClose}
+      onClick={() => !downloading && onClose()}
     >
       <div
         className="bg-white p-8 rounded-xl shadow-2xl max-w-lg w-full relative transform transition-all duration-300 ease-out scale-100 opacity-100"
@@ -76,6 +90,30 @@ function DownloadOptions({ onClose, chartImageUrl }) {
           <X className="w-6 h-6" />
         </button>
 
+        {downloadSuccessful ? (
+          <div>
+            <div className="flex flex-col items-center justify-center">
+              <CheckCircle className="w-16 h-16 text-green-500 mb-4" />
+              <h3 className="text-2xl font-bold text-gray-800 mb-2">Success!</h3>
+              <p className="text-gray-600 text-center mb-6">Your chart has been successfully downloaded.</p>
+            </div>
+            <div className="space-y-4">
+              <button
+                onClick={handleContinueEditing}
+                className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 px-4 rounded-lg shadow-md transition duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
+              >
+                Continue Editing
+              </button>
+              <button
+                onClick={handleMakeAnotherChart}
+                className="w-full bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold py-3 px-4 rounded-lg shadow-md transition duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-opacity-75"
+              >
+                Make Another Chart
+              </button>
+            </div>
+          </div>
+        ) : (
+        <div>
         <h3 className="text-gray-800 text-center">Choose Download Format</h3>
 
         <div className="space-y-4 mt-5">
@@ -119,6 +157,8 @@ function DownloadOptions({ onClose, chartImageUrl }) {
           </button>
         </div>
       </div>
+      )}
+    </div>
     </div>
   );
 }

--- a/src/frontend/project-src/pages/EditSave.jsx
+++ b/src/frontend/project-src/pages/EditSave.jsx
@@ -7,7 +7,7 @@ import generateChartUrl from "../utils/generateChartURL";
 import { useState, useEffect } from "react";
 // import FontPicker from 'font-picker-react'; // Replaced with custom Noto fonts dropdown
 import DownloadOptions from '../components/editchart/DownloadOptions';
-import { Text, Paintbrush, Download, Edit3, RotateCcw, RotateCw, RefreshCw } from 'lucide-react';
+import { Loader2, Text, Paintbrush, Download, Edit3, RotateCcw, RotateCw, RefreshCw } from 'lucide-react';
 
 const quickChartURL = "https://quickchart.io/chart?height=500&backgroundColor=white&v=4&c=";
 
@@ -55,6 +55,7 @@ function EditSave() {
     const { chartConfig: initialConfig } = location.state || {};
     const [showBackgroundPicker, setShowBackgroundPicker] = useState(false);
     const [showTextPicker, setShowTextPicker] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
     console.log(initialConfig);
 
     const [chartConfig, setChartConfig] = useState(initialConfig);
@@ -447,6 +448,13 @@ function EditSave() {
         
         updateChartConfig(updated);
     };
+
+    useEffect(() => {
+    if (chartConfig) {
+        setIsLoading(true);
+        setChartImageUrl(`${quickChartURL}${encodeURIComponent(JSON.stringify(chartConfig))}`);
+    }
+}, [chartConfig]);
     
 {/* BELOW IS WHERE ALL OF THE BUTTONS ARE LOCATED */}
 
@@ -456,7 +464,7 @@ function EditSave() {
             <div className="bg-blue-50 rounded-2xl shadow-lg px-4 sm:px-6 md:px-8 py-6 w-full">
                 <div className="flex flex-col md:flex-row gap-8 w-full">
                     {/* Display the chart image */}
-                    <div className="flex-1 bg-white rounded-xl p-4 sm:p-6 shadow-lg">
+                    <div className="flex-1 bg-white rounded-xl p-4 sm:p-6 shadow-lg relative">
                         <div>
                             <h2 className="font-semibold flex items-center justify-center gap-4 mb-2">
                             {/* <Edit3 size={30} />
@@ -492,15 +500,23 @@ function EditSave() {
                             </h2>
 
                             {/* !!!! this is where the image is shown */}
-                            {chartImageUrl ? (
-                            <img
-                                src={`${quickChartURL}${encodeURIComponent(JSON.stringify(chartConfig))}`}
-                                alt="Live Chart Preview"
-                                className="w-full max-w-md mx-auto rounded-md shadow-md"
-                            />
-                            ) : (
-                            <p className="text-center text-gray-500">No chart available</p>
-                            )}
+                            <>
+                                {isLoading && (
+                                    <div className="absolute top-0 left-0 w-full h-full flex items-center justify-center rounded-md z-10" style={{ backgroundColor: 'rgba(255, 255, 255, 0.5)' }}>
+                                        <Loader2 size={48} className="animate-spin text-blue-500" />
+                                    </div>
+                                )}
+                                {chartImageUrl ? (
+                                <img
+                                    src={`${quickChartURL}${encodeURIComponent(JSON.stringify(chartConfig))}`}
+                                    alt="Live Chart Preview"
+                                    onLoad={() => setIsLoading(false)} 
+                                    className="w-full max-w-md mx-auto rounded-md shadow-md"
+                                />
+                                ) : (
+                                <p className="text-center text-gray-500">No chart available</p>
+                                )}
+                            </>
                         </div>
                     </div>
 

--- a/src/frontend/project-src/pages/EditSave.jsx
+++ b/src/frontend/project-src/pages/EditSave.jsx
@@ -637,6 +637,7 @@ function EditSave() {
                             <SketchPicker
                             color={tempBackgroundColor}
                             onChangeComplete={(color) => setTempBackgroundColor(color.hex)}
+                            disableAlpha={true}
                             />
                         </div>
                         )}
@@ -647,6 +648,7 @@ function EditSave() {
                             <SketchPicker
                             color={tempTextColor}
                             onChangeComplete={(color) => setTempTextColor(color.hex)}
+                            disableAlpha={true}
                             />
                         </div>
                         )}

--- a/src/frontend/project-src/pages/EditSave.jsx
+++ b/src/frontend/project-src/pages/EditSave.jsx
@@ -581,7 +581,7 @@ function EditSave() {
 
                                 {/* This is the button where they choose the background colour*/}
                                 <button
-                                className="flex-1 bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition cursor-pointer"
+                                className={`flex-1 ${showBackgroundPicker ? 'bg-cyan-500 hover:bg-cyan-600' : 'bg-blue-600 hover:bg-blue-700'} text-white px-4 py-2 rounded-md transition cursor-pointer`}
                                 onClick={() => {
                                     if (showBackgroundPicker) {
                                     setSelectedColor(tempBackgroundColor); // final color to state
@@ -589,15 +589,16 @@ function EditSave() {
                                     setShowBackgroundPicker(false); // hide picker
                                     } else {
                                     setShowBackgroundPicker(true); // open picker
+                                    setShowTextPicker(false);
                                     }
                                 }}
                                 >
-                                {showBackgroundPicker ? "Confirm Colour" : "Edit Background"}
+                                {showBackgroundPicker ? "Confirm Chart Colour" : "Chart Colour"}
                                 </button>
 
                                 {/* This is the button where they choose the text colour*/}
                                 <button
-                                className="flex-1 bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition cursor-pointer"
+                                className={`flex-1 ${showTextPicker ? 'bg-cyan-500 hover:bg-cyan-600' : 'bg-blue-600 hover:bg-blue-700'} text-white px-4 py-2 rounded-md transition cursor-pointer`}
                                 onClick={() => {
                                     if (showTextPicker) {
                                     setTextColor(tempTextColor);
@@ -605,10 +606,11 @@ function EditSave() {
                                     setShowTextPicker(false);
                                     } else {
                                     setShowTextPicker(true);
+                                    setShowBackgroundPicker(false);
                                     }
                                 }}
                                 >
-                                {showTextPicker ? "Confirm Colour" : "Edit Text"}
+                                {showTextPicker ? "Confirm Text Colour" : "Text Colour"}
                                 </button>
                             </div>
                         </div>
@@ -646,7 +648,7 @@ function EditSave() {
                             className="w-full bg-blue-600 hover:bg-gray-300 text-white font-semibold py-2 px-4 rounded-lg shadow-sm transition duration-200 ease-in-out flex items-center justify-center gap-2 cursor-pointer"
                             onClick={() => setIsDownloadModalOpen(true)}
                         >
-                            <Download size={18} />
+                            <Download size={18} strokeWidth={4}/>
                             Download
                         </button>
                         </div>

--- a/src/frontend/project-src/pages/EditSave.jsx
+++ b/src/frontend/project-src/pages/EditSave.jsx
@@ -7,7 +7,7 @@ import generateChartUrl from "../utils/generateChartURL";
 import { useState, useEffect } from "react";
 // import FontPicker from 'font-picker-react'; // Replaced with custom Noto fonts dropdown
 import DownloadOptions from '../components/editchart/DownloadOptions';
-import { Download, Edit3, RotateCcw, RotateCw, RefreshCw } from 'lucide-react';
+import { Text, Paintbrush, Download, Edit3, RotateCcw, RotateCw, RefreshCw } from 'lucide-react';
 
 const quickChartURL = "https://quickchart.io/chart?height=500&backgroundColor=white&v=4&c=";
 
@@ -459,8 +459,8 @@ function EditSave() {
                     <div className="flex-1 bg-white rounded-xl p-4 sm:p-6 shadow-lg">
                         <div>
                             <h2 className="font-semibold flex items-center justify-center gap-4 mb-2">
-                            <Edit3 size={30} />
-                            Edit Chart
+                            {/* <Edit3 size={30} />
+                            Edit Chart */}
 
                             <div className="flex ml-6 space-x-3">
                                 <button
@@ -510,7 +510,10 @@ function EditSave() {
 
                         {/* Chart Title section */}
                         <div className="bg-white rounded-2xl shadow-md p-4 border border-gray-200 space-y-4">
-                            <p className="text-lg font-semibold text-gray-800 mb-2">Chart Title</p>
+                            <div className="flex items-center gap-2 mb-2">
+                                <Text size={18} className="text-black" strokeWidth={2.5} />
+                                <p className="text-lg font-semibold text-gray-800">Chart Title</p>
+                            </div>
                             <div className="flex gap-2">
                                 <input
                                     type="text"
@@ -531,7 +534,10 @@ function EditSave() {
 
                         {/* this is the "text" section card*/}
                         <div className="bg-white rounded-2xl shadow-md p-4 border border-gray-200 space-y-4">
-                            <p className="text-lg font-semibold text-gray-800 mb-2">Text</p>
+                            <div className="flex items-center gap-2 mb-2">
+                                <Edit3 size={18} className="text-black" strokeWidth={2.5} />
+                                <p className="text-lg font-semibold text-gray-800">Edit Text</p>
+                            </div>
                             <div className="flex flex-col sm:flex-row gap-4">
                                 <div className="flex-1">
                                     <select
@@ -567,7 +573,10 @@ function EditSave() {
 
                         {/* This is the colour card */}
                         <div className="bg-white rounded-2xl shadow-md p-4 border border-gray-200 space-y-4">
-                            <p className="text-lg font-semibold text-gray-800 mb-2">Colour</p>
+                            <div className="flex items-center gap-2 mb-2">
+                                <Paintbrush size={18} className="text-black" strokeWidth={2.5}/>
+                                <p className="text-lg font-semibold text-gray-800">Edit Colour</p>
+                            </div>
                             <div className="flex flex-col sm:flex-row gap-4">
 
                                 {/* This is the button where they choose the background colour*/}


### PR DESCRIPTION
Updated the edit-save page to incorporate feedback we got after user testing. This included changing the editing buttons so their names made more sense and the colours changed to indicate a state change. Added a loading wheel while changes are being applied. Made a "success" message to indicate a chart has been downloaded correctly. Made other minor styling changes.