### PR TITLE
BUG fix: Issue: #198

### DIFF
--- a/src/backend/app.js
+++ b/src/backend/app.js
@@ -42,7 +42,7 @@ app.use(cors({
 
 
 app.get('/get-session-data', async (req, res) => {
-    res.json(sessionData);
+    return res.json(sessionData);
 });
 
 app.post('/file-submit', upload.array('files'), async (req, res) => {
@@ -65,9 +65,10 @@ app.post('/file-submit', upload.array('files'), async (req, res) => {
                 buffer: fs.readFileSync(txtFilePath)
             };
 
-            let result = { parsedData: await parseFile(file), file: file };
             sessionData.uploadedFile = file;
-            sessionData.parsedData = result.parsedData;
+            sessionData.parsedData = await parseFile(file);
+            sessionData.edittedData = sessionData.parsedData;
+            let result = { parsedData: sessionData.parsedData, edittedData: sessionData.edittedData, file: file };
             return res.json(result);
         } catch (error) {
             if (error.code === 'NO_DATA_EXTRACTED') {
@@ -80,9 +81,10 @@ app.post('/file-submit', upload.array('files'), async (req, res) => {
 
     try {
         const file = files[0];
-        let result = { parsedData: await parseFile(file), file: file };
         sessionData.uploadedFile = file;
-        sessionData.parsedData = result.parsedData;
+        sessionData.parsedData = await parseFile(file);
+        sessionData.edittedData = sessionData.parsedData;
+        let result = { parsedData: sessionData.parsedData, edittedData: sessionData.edittedData, file: file };
         return res.json(result);
     } catch (error) {
         if (error.code === 'NO_DATA_EXTRACTED') {

--- a/src/frontend/project-src/pages/EditData.jsx
+++ b/src/frontend/project-src/pages/EditData.jsx
@@ -20,7 +20,7 @@ function EditData() {
   const location = useLocation();
   const navigate = useNavigate();
 
-  const { parsedData } = location.state || {};
+  const { parsedData, edittedData } = location.state || {};
   const { isAlertVisible, alertConfig, showAlert, hideAlert } = useDefaultError();
 
   const [isLoading, setIsLoading] = useState(false);
@@ -42,16 +42,13 @@ function EditData() {
 
   // Initialize confirmedData and originalData from parsedData
   useEffect(() => {
-    if (!parsedData) {
-      navigate("/");
-      return;
-    }
+    const {table: originalTable}  = convertDeepSeekToTable(parsedData);
+    const {table: currentTable}  = convertDeepSeekToTable(edittedData);
 
-    const { table } = convertDeepSeekToTable(parsedData);
-    setConfirmedData(structuredClone(table));
-    setUndoStack([structuredClone(table)]);
-    setOriginalData(structuredClone(table));
-  }, [parsedData, navigate]);
+    setConfirmedData(structuredClone(currentTable));
+    setUndoStack([structuredClone(currentTable)]);
+    setOriginalData(structuredClone(originalTable));
+  }, [parsedData, edittedData, navigate]);
 
   useEffect(() => {
     const handleClickOutside = (event) => {
@@ -80,8 +77,7 @@ function EditData() {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        edittedData: formattedData,
-        parsedData: parsedData,
+        edittedData: formattedData
       }),
       credentials: "include",
     });

--- a/src/frontend/project-src/pages/HomePage.jsx
+++ b/src/frontend/project-src/pages/HomePage.jsx
@@ -52,7 +52,7 @@ function HomePage() {
       body: formData,
       credentials: 'include'
     })
-     .then(async (response) => { //// to go to the next page if successful
+     .then(async (response) => {
       const data = await response.json();
       if (!response.ok) {
         const error = new Error(data.error || 'Something went wrong');
@@ -62,7 +62,7 @@ function HomePage() {
       return data;
     })
     .then((data) => {
-      if (data && data.parsedData && data.file) {
+      if (data && data.parsedData && data.edittedData && data.file) {
         navigate('/edit-data', { state: data, replace: true });
       } else {
         const error = new Error(data.error || 'Something went wrong');

--- a/src/frontend/project-src/pages/VisualSelect.jsx
+++ b/src/frontend/project-src/pages/VisualSelect.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { ChevronLeft, ClipboardList } from "lucide-react";
 
 import ChartSelectionCard from "../components/visualselect/ChartSelectionCard";
 import ProgressStepper from "../components/layout/ProgressStepper";
@@ -16,30 +15,25 @@ function VisualSelect() {
 
   // Function to get session data and navigate back to edit-data
   const getSessionDataAndNavigateBack = async () => {
-    try {
-      const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/get-session-data`, {
+      fetch(`${import.meta.env.VITE_API_BASE_URL}/get-session-data`, {
         method: "GET",
         headers: { "Content-Type": "application/json" },
-        credentials: "include", // Include cookies for session management
+        credentials: "include"
+      })
+      .then(async (response) => {
+        const data = await response.json();
+        if (!response.ok){
+          const error = new Error(`HTTP error! status: ${response.status}`);
+          throw error;
+        }
+        return data;
+      })
+      .then((data) => {
+        navigate('/edit-data', {state: data, replace: true});
+      })
+      .catch((error) => {
+        alert(error.message, "Please try again.");
       });
-
-      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-
-      const sessionData = await response.json();
-    
-      // Navigate back to edit-data with the retrieved data
-      navigate("/edit-data", {
-        state: {
-          parsedData: sessionData.edittedData,
-          file: sessionData.uploadedFile,
-          summary: sessionData.summary,
-          graphRecommendation: sessionData.graphRecommendation,
-          chartsWithURLs: sessionData.chartsWithURLs,
-        },
-      });
-    } catch (error) {
-      alert(error.message, "Please try again.");
-    }
   };
 
   const handleChartSelect = (chart) => {

--- a/src/frontend/project-src/utils/DeepSeekToTable.jsx
+++ b/src/frontend/project-src/utils/DeepSeekToTable.jsx
@@ -2,7 +2,7 @@ function convertDeepSeekToTable(parsedData) {
   if (!Array.isArray(parsedData) || parsedData.length === 0) {
     return {
       table: {
-        rowHeaderTitle: "Row",
+        rowHeaderTitle: '',
         columns: [],
         rows: [],
       },


### PR DESCRIPTION
- Description: After confirming changes to the data and proceeding to the next page (Visual Select). If the user goes back to the data edit page and attempt to revert to the first copy of the data, it will not work.
- Solution: Found flaw in data transfer between pages.
- It was fixed by modifying the logic of how the graphs are generated so it keeps a copy of the first ever data, then a copy of the most recent changes.
- Fixed syntax issues in Visual Select for when going to a previous page.